### PR TITLE
fix wget output file option; closes #5

### DIFF
--- a/bash/daymet_spt_batch.sh
+++ b/bash/daymet_spt_batch.sh
@@ -4,7 +4,7 @@ years="1980,1981,1982,1983,1984,1985,1986,1987,1988,1989"
 years+=",1990,1991,1992,1993,1994,1995,1996,1997,1998,1999"
 years+=",2000,2001,2002,2003,2004,2005,2006,2007,2008,2009"
 years+=',2010,2011,2012,2013,2014,2015,2016,2017,2018,2019'
-years+=',2020'
+years+=',2020,2021,2022'
 vars="dayl,prcp,srad,swe,tmax,tmin,vp"
 # read in first command line argument (should be latlon.txt)
 inF=$1
@@ -55,7 +55,7 @@ if [ -x "$(command -v curl)" ]; then
 else
   if [ -x "$(command -v wget)" ]; then
     downloadwName() { wget --content-disposition -q $1; }
-    download() { wget -q $1 -o $2; }
+    download() { wget -q $1 -O $2; }
   else
     echo "Error: You must have either curl or wget installed to run this program."
     exit 1


### PR DESCRIPTION
This is a simple fix as described in #5; after this change we have
```
$ head file1.csv
Latitude: 45.0  Longitude: -97.0
X & Y on Lambert Conformal Conic: 225570.36 268920.61
Tile: 12102
Elevation: 603 meters
All years; all variables; Daymet Software Version 4.0
How to cite: Thornton; M.M.; R. Shrestha; Y. Wei; P.E. Thornton; S. Kao; and B.E. Wilson. 2020. Daymet: Daily Surface Weather Data on a 1-km Grid for North America; Version 4. ORNL DAAC; Oak Ridge; Tennessee; USA.  https://doi.org/10.3334/ORNLDAAC/1840 

year,yday,prcp (mm/day),tmax (deg c),tmin (deg c)
2012,1,0.00,-1.70,-7.05
2012,2,0.00,-5.66,-13.86

```

I've also added 2021 and 2022 to the example file, but can back out that change if that'd be better.